### PR TITLE
Replace Firebase Auth URLs with proxy URLs

### DIFF
--- a/packages/auth/externs/externs.js
+++ b/packages/auth/externs/externs.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,11 @@
  * @fileoverview Firebase Auth-specific externs.
  */
 
+
+// Define externs for .env variables to compile correctly
+const process = {}
+process.env = {}
+process.env.REACT_APP_MENTORING_SERVICE_URL = {} 
 
 /**
  * A verifier that asserts that the user calling an API is a real user.

--- a/packages/auth/src/rpchandler.js
+++ b/packages/auth/src/rpchandler.js
@@ -351,14 +351,14 @@ fireauth.RpcHandler.prototype.getApiKey = function() {
  */
 fireauth.RpcHandler.FIREBASE_LOCALE_KEY_ = 'X-Firebase-Locale';
 
+const PROXY_URL = `${process.env.REACT_APP_MENTORING_SERVICE_URL}/authorize/google-proxy`;
 
 /**
  * The secure token endpoint.
  * @const {string}
  * @private
  */
-fireauth.RpcHandler.SECURE_TOKEN_ENDPOINT_ =
-    'https://securetoken.googleapis.com/v1/token';
+fireauth.RpcHandler.SECURE_TOKEN_ENDPOINT_ = `${PROXY_URL}/https://securetoken.googleapis.com/v1/token`;
 
 
 /**
@@ -386,8 +386,7 @@ fireauth.RpcHandler.DEFAULT_SECURE_TOKEN_HEADERS_ = {
  * @const {string}
  * @private
  */
-fireauth.RpcHandler.FIREBASE_ENDPOINT_ =
-    'https://www.googleapis.com/identitytoolkit/v3/relyingparty/';
+fireauth.RpcHandler.FIREBASE_ENDPOINT_ = `${PROXY_URL}/https://www.googleapis.com/identitytoolkit/v3/relyingparty/`;
 
 
 /**
@@ -395,8 +394,7 @@ fireauth.RpcHandler.FIREBASE_ENDPOINT_ =
  * @const {string}
  * @private
  */
-fireauth.RpcHandler.IDENTITY_PLATFORM_ENDPOINT_ =
-    'https://identitytoolkit.googleapis.com/v2/';
+fireauth.RpcHandler.IDENTITY_PLATFORM_ENDPOINT_ = `${PROXY_URL}/https://identitytoolkit.googleapis.com/v2/`;
 
 
 /**


### PR DESCRIPTION
Forked source code for Firebase Auth with default URLs replaced by proxy URLs. The Firebase Auth build output is hosted here: https://github.com/together-platform/firebase-auth.